### PR TITLE
ability use backblaze b2

### DIFF
--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -16,10 +16,12 @@ func Test(t *testing.T) {
 	secretAccessKey := os.Getenv("SECRET_ACCESS_KEY")
 	region := os.Getenv("AWS_REGION")
 	bucket := os.Getenv("S3_BUCKET")
+	endpoint := os.Getenv("S3_ENDPOINT")
 
 	if accessKeyID == "" ||
 		secretAccessKey == "" ||
 		region == "" ||
+		endpoint == "" ||
 		bucket == "" {
 		t.SkipNow()
 	}
@@ -28,6 +30,8 @@ func Test(t *testing.T) {
 		SecretAccessKey: secretAccessKey,
 		Region:          region,
 		Bucket:          bucket,
+		Endpoint:        &endpoint,
+		ACL:             "private",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -17,11 +17,13 @@ func Test(t *testing.T) {
 	region := os.Getenv("AWS_REGION")
 	bucket := os.Getenv("S3_BUCKET")
 	endpoint := os.Getenv("S3_ENDPOINT")
+	acl := os.Getenv("S3_ACL")
 
 	if accessKeyID == "" ||
 		secretAccessKey == "" ||
 		region == "" ||
 		endpoint == "" ||
+		acl == "" ||
 		bucket == "" {
 		t.SkipNow()
 	}
@@ -31,7 +33,7 @@ func Test(t *testing.T) {
 		Region:          region,
 		Bucket:          bucket,
 		Endpoint:        &endpoint,
-		ACL:             "private",
+		ACL:             acl,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
somehow have to be able to set endpoint to s3.us-west-002.backblazeb2.com
and my storage is private so it fails on hardcoded `s3.ObjectCannedACLPublicRead = "public-read"`

ACL should be configurable according to : https://raw.githubusercontent.com/aws/aws-sdk-go/master/service/s3/api.go line number 35546
```
const (
    // ObjectCannedACLPrivate is a ObjectCannedACL enum value
    ObjectCannedACLPrivate = "private"

    // ObjectCannedACLPublicRead is a ObjectCannedACL enum value
    ObjectCannedACLPublicRead = "public-read"

    // ObjectCannedACLPublicReadWrite is a ObjectCannedACL enum value
    ObjectCannedACLPublicReadWrite = "public-read-write"

    // ObjectCannedACLAuthenticatedRead is a ObjectCannedACL enum value
    ObjectCannedACLAuthenticatedRead = "authenticated-read"

    // ObjectCannedACLAwsExecRead is a ObjectCannedACL enum value
    ObjectCannedACLAwsExecRead = "aws-exec-read"

    // ObjectCannedACLBucketOwnerRead is a ObjectCannedACL enum value
    ObjectCannedACLBucketOwnerRead = "bucket-owner-read"

    // ObjectCannedACLBucketOwnerFullControl is a ObjectCannedACL enum value
    ObjectCannedACLBucketOwnerFullControl = "bucket-owner-full-control"
)
```